### PR TITLE
Added package.json so plugin will install in Cordova >7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-ios-keychain",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Keychain Plugin for Apache Cordova ===================================== created by Shazron Abdullah",
   "main": "index.js",
   "directories": {
@@ -11,13 +11,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wilkesreid/cordova-plugin-ios-keychain.git"
+    "url": "git+https://github.com/driftyco/cordova-plugin-ios-keychain.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/wilkesreid/cordova-plugin-ios-keychain/issues"
+    "url": "https://github.com/driftyco/cordova-plugin-ios-keychain/issues"
   },
-  "homepage": "https://github.com/wilkesreid/cordova-plugin-ios-keychain#readme"
+  "homepage": "https://github.com/driftyco/cordova-plugin-ios-keychain#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cordova-plugin-ios-keychain",
+  "version": "1.0.0",
+  "description": "Keychain Plugin for Apache Cordova ===================================== created by Shazron Abdullah",
+  "main": "index.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wilkesreid/cordova-plugin-ios-keychain.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/wilkesreid/cordova-plugin-ios-keychain/issues"
+  },
+  "homepage": "https://github.com/wilkesreid/cordova-plugin-ios-keychain#readme"
+}


### PR DESCRIPTION
Pretty self-explanatory. Reference: [this issue](https://github.com/driftyco/cordova-plugin-ios-keychain/issues/21).