### PR TITLE
fix(set): make useTouchID truly optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cordova-plugin-ios-keychain",
+  "version": "2.0.0",
+  "description": "Keychain Plugin for Apache Cordova ===================================== created by Shazron Abdullah",
+  "main": "index.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/driftyco/cordova-plugin-ios-keychain.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/driftyco/cordova-plugin-ios-keychain/issues"
+  },
+  "homepage": "https://github.com/driftyco/cordova-plugin-ios-keychain#readme"
+}

--- a/www/keychain.js
+++ b/www/keychain.js
@@ -29,7 +29,7 @@ var Keychain = {
 		exec(success, error, this.serviceName, "get", [key, touchIDMessage]);
 	},
 	set: function(success, error, key, value, useTouchID) {
-		exec(success, error, this.serviceName, "set", [key, value, useTouchID]);
+		exec(success, error, this.serviceName, "set", [key, value, !!useTouchID]);
 	},
 
 	setJson: function(success, error, key, obj, useTouchID) {
@@ -44,7 +44,7 @@ var Keychain = {
 			.replace(/[\r]/g, '\\r')
 			.replace(/[\t]/g, '\\t');
 
-		exec(success, error, this.serviceName, "set", [key, value, useTouchID]);
+		exec(success, error, this.serviceName, "set", [key, value, !!useTouchID]);
 	},
 
 	getJson: function(success, error, key, touchIDMessage) {


### PR DESCRIPTION
Currently apps will crash if the `useTouchID` value is omitted when setting properties, but the documentation seems to indicate that this argument is optional.

This updates the code to convert an undefined value to `false` for proper use by the plugin.